### PR TITLE
Add linking to glib-2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,11 @@ DESTDIR ?= /
 CFLAGS = -O3 -Wall -Werror -flto
 CFLAGS += `pkg-config --cflags libgbinder`
 CFLAGS += `pkg-config --cflags libsystemd`
+CFLAGS += `pkg-config --cflags glib-2.0`
 
 LIBS += `pkg-config --libs libgbinder`
 LIBS += `pkg-config --libs libsystemd`
+LIBS += `pkg-config --libs glib-2.0`
 
 dummy_netd: $(OBJS)
 	$(CC) $(LDFLAGS) $(OBJS) $(LIBS) -o $@

--- a/rpm/dummy_netd.spec
+++ b/rpm/dummy_netd.spec
@@ -10,6 +10,7 @@ Source:         %{name}-%{version}.tar.bz2
 
 BuildRequires:  libgbinder-devel >= 1.0.7
 BuildRequires:  pkgconfig(libsystemd)
+BuildRequires:  pkgconfig(glib-2.0)
 
 %description
 dummy_netd provides the android.system.net.netd@1.1 service for devices which cannot work without it.


### PR DESCRIPTION
This fixes a undefined symbol when compile.

Err log:
```
/srv/mer/toolings/SailfishOS-3.3.0.16//opt/cross/bin/armv7hl-meego-linux-gnueabi-ld: /tmp/ccNqtV3a.ltrans0.ltrans.o: undefined reference to symbol 'g_main_loop_unref'
/srv/mer/toolings/SailfishOS-3.3.0.16//opt/cross/bin/armv7hl-meego-linux-gnueabi-ld: /srv/mer/targets/xiaomi-lavender-armv7hl/usr/lib/libglib-2.0.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make: *** [Makefile:13: dummy_netd] Error 1
error: Bad exit status from /var/tmp/rpm-tmp.WnN4z9 (%build)
```