### PR TITLE
More reliable startup and a bunch of assorted changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-dummy_netd
-dummy_netd.o
+build
+*~

--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,148 @@
-OBJS = dummy_netd.o
+.PHONY: all debug release clean install
+
+#
+# These are often defined by the build
+#
 
 DESTDIR ?= /
+UNITDIR ?= usr/lib/systemd/system
 
-CFLAGS = -O3 -Wall -Werror -flto
-CFLAGS += `pkg-config --cflags libgbinder`
-CFLAGS += `pkg-config --cflags libsystemd`
-CFLAGS += `pkg-config --cflags glib-2.0`
+#
+# Required packages
+#
 
-LIBS += `pkg-config --libs libgbinder`
-LIBS += `pkg-config --libs libsystemd`
-LIBS += `pkg-config --libs glib-2.0`
+LIB_PKGS = libgbinder libsystemd glib-2.0
+PKGS = $(LIB_PKGS)
 
-dummy_netd: $(OBJS)
-	$(CC) $(LDFLAGS) $(OBJS) $(LIBS) -o $@
+#
+# Default target
+#
 
-install:
-	mkdir -p $(DESTDIR)/usr/sbin
-	cp dummy_netd $(DESTDIR)/usr/sbin
+all: debug release
+
+#
+# Sources
+#
+
+SRC = dummy_netd.c
+
+#
+# Directories
+#
+
+SRC_DIR = .
+BUILD_DIR = build
+DEBUG_BUILD_DIR = $(BUILD_DIR)/debug
+RELEASE_BUILD_DIR = $(BUILD_DIR)/release
+
+#
+# Tools and flags
+#
+
+CC = $(CROSS_COMPILE)gcc
+LD = $(CC)
+DEBUG_FLAGS = -g
+RELEASE_FLAGS =
+DEBUG_DEFS = -DDEBUG
+RELEASE_DEFS =
+WARNINGS = -Wall -Wunused-result
+FULL_CFLAGS = $(CFLAGS) $(DEFINES) $(WARNINGS) $(INCLUDES) \
+  -MMD -MP $(shell pkg-config --cflags $(PKGS))
+FULL_LDFLAGS = $(LDFLAGS)
+
+KEEP_SYMBOLS ?= 0
+ifneq ($(KEEP_SYMBOLS),0)
+RELEASE_FLAGS += -g
+SUBMAKE_OPTS += KEEP_SYMBOLS=1
+endif
+
+DEBUG_CFLAGS = $(DEBUG_FLAGS) -DDEBUG $(FULL_CFLAGS)
+RELEASE_CFLAGS = $(RELEASE_FLAGS) -O2 $(FULL_CFLAGS)
+DEBUG_LDFLAGS = $(DEBUG_FLAGS) $(FULL_LDFLAGS)
+RELEASE_LDFLAGS = $(RELEASE_FLAGS) $(FULL_LDFLAGS)
+
+LIBS = $(shell pkg-config --libs $(LIB_PKGS))
+DEBUG_LIBS = $(LIBS)
+RELEASE_LIBS = $(LIBS)
+
+#
+# Files
+#
+
+DEBUG_OBJS = $(SRC:%.c=$(DEBUG_BUILD_DIR)/%.o)
+RELEASE_OBJS = $(SRC:%.c=$(RELEASE_BUILD_DIR)/%.o)
+
+#
+# Dependencies
+#
+
+DEPS = \
+  $(DEBUG_OBJS:%.o=%.d) \
+  $(RELEASE_OBJS:%.o=%.d)
+ifneq ($(MAKECMDGOALS),clean)
+ifneq ($(strip $(DEPS)),)
+-include $(DEPS)
+endif
+endif
+
+$(DEBUG_OBJS): | $(DEBUG_BUILD_DIR)
+$(RELEASE_OBJS): | $(RELEASE_BUILD_DIR)
+
+#
+# Rules
+#
+
+EXE = dummy_netd
+DEBUG_EXE = $(DEBUG_BUILD_DIR)/$(EXE)
+RELEASE_EXE = $(RELEASE_BUILD_DIR)/$(EXE)
+
+
+debug: $(DEBUG_EXE)
+
+release: $(RELEASE_EXE)
 
 clean:
-	$(RM) $(OBJS) dummy_netd
+	rm -fr *~ */*~ rpm/*~ $(BUILD_DIR)
 
-%.o: %.c
-	$(CC) $(CFLAGS) -c $< -o $@
+$(DEBUG_BUILD_DIR):
+	mkdir -p $@
 
-all: dummy_netd
+$(RELEASE_BUILD_DIR):
+	mkdir -p $@
 
+$(DEBUG_BUILD_DIR)/%.o: $(SRC_DIR)/%.c
+	$(CC) -c $(WARN) $(DEBUG_CFLAGS) -MT"$@" -MF"$(@:%.o=%.d)" $< -o $@
+
+$(RELEASE_BUILD_DIR)/%.o: $(SRC_DIR)/%.c
+	$(CC) -c $(WARN) $(RELEASE_CFLAGS) -MT"$@" -MF"$(@:%.o=%.d)" $< -o $@
+
+$(DEBUG_EXE): $(DEBUG_OBJS)
+	$(LD) $(DEBUG_LDFLAGS) $(DEBUG_OBJS) $(DEBUG_LIBS) -o $@
+
+$(RELEASE_EXE): $(RELEASE_OBJS)
+	$(LD) $(RELEASE_LDFLAGS) $(RELEASE_OBJS) $(RELEASE_LIBS) -o $@
+ifeq ($(KEEP_SYMBOLS),0)
+	strip $@
+endif
+
+#
+# Install
+#
+
+DESTDIR_ := $(shell echo $(DESTDIR)/ | sed -r 's|/+|/|g')
+
+INSTALL = install
+INSTALL_DIRS = $(INSTALL) -d
+
+INSTALL_SBIN_DIR = $(DESTDIR_)usr/sbin
+INSTALL_SYSTEMD_DIR = $(DESTDIR_)$(UNITDIR)
+
+install: $(RELEASE_EXE) $(INSTALL_SBIN_DIR) $(INSTALL_SYSTEMD_DIR)
+	$(INSTALL) -m 644 dummy_netd.service $(INSTALL_SYSTEMD_DIR)
+	$(INSTALL) -m 755 $(RELEASE_EXE) $(INSTALL_SBIN_DIR)
+
+$(INSTALL_SBIN_DIR):
+	$(INSTALL_DIRS) $@
+
+$(INSTALL_SYSTEMD_DIR):
+	$(INSTALL_DIRS) $@

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ UNITDIR ?= usr/lib/systemd/system
 # Required packages
 #
 
-LIB_PKGS = libgbinder libsystemd glib-2.0
+LIB_PKGS = libgbinder libglibutil libsystemd glib-2.0
 PKGS = $(LIB_PKGS)
 
 #

--- a/dummy_netd.c
+++ b/dummy_netd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Jolla Ltd.
+ * Copyright (C) 2019-2020 Jolla Ltd.
  * Copyright (C) 2019 Franz-Josef Haider <franz.haider@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
@@ -30,17 +30,34 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <stdio.h>
+#include <glib.h>
+#include <glib-unix.h>
 #include <gbinder.h>
+#include <gutil_log.h>
 #include <systemd/sd-daemon.h>
+#include <stdio.h>
 
 #define BINDER_DEVICE "/dev/hwbinder"
 #define NETD_IFACE "android.system.net.netd@1.1::INetd"
 #define NETD_SLOT "default"
 
+#define RET_OK      0
+#define RET_CMDLINE 1
+#define RET_ERR     2
+
+static
+gboolean
+netd_signal(
+    gpointer user_data)
+{
+    GINFO("Signal caught, exiting...");
+    g_main_loop_quit((GMainLoop*) user_data);
+    return G_SOURCE_CONTINUE;
+}
+
 static
 GBinderLocalReply*
-netd_reply(
+netd_handler(
     GBinderLocalObject* obj,
     GBinderRemoteRequest* req,
     guint code,
@@ -48,44 +65,91 @@ netd_reply(
     int* status,
     void* user_data)
 {
-    fprintf(stderr, "netd_reply called with on interface: %s, code: %d, flags: %d\n",
-                    gbinder_remote_request_interface(req), code, flags);
+    GDEBUG("%s %d", gbinder_remote_request_interface(req), code);
     return NULL;
 }
 
 static
-void
-add_service_done(
-    GBinderServiceManager* sm,
-    int status,
-    void* user_data)
+gboolean
+netd_opt_verbose(
+    const gchar* name,
+    const gchar* value,
+    gpointer data,
+    GError** error)
 {
-    if (status == GBINDER_STATUS_OK) {
+    gutil_log_default.level = (gutil_log_default.level < GLOG_LEVEL_DEBUG) ?
+        GLOG_LEVEL_DEBUG : GLOG_LEVEL_VERBOSE;
+    return TRUE;
+}
+
+static
+int
+netd_run(
+    const char* dev)
+{
+    GBinderServiceManager* svcmgr = gbinder_servicemanager_new(dev);
+
+    if (svcmgr) {
+        GMainLoop* loop = g_main_loop_new(NULL, TRUE);
+        guint sigterm = g_unix_signal_add(SIGTERM, netd_signal, loop);
+        guint sigint = g_unix_signal_add(SIGINT, netd_signal, loop);
+        GBinderLocalObject* obj = gbinder_servicemanager_new_local_object
+            (svcmgr, NETD_IFACE, netd_handler, NULL);
+        GBinderServiceName* name = gbinder_servicename_new
+            (svcmgr, obj, NETD_SLOT);
+
+        /* Do we need to wait until the name is actually registered? */
         sd_notify(0, "READY=1");
+
+        /* Run the event loop */
+        g_main_loop_run(loop);
+
+        /* Exiting on signal */
+        g_source_remove(sigterm);
+        g_source_remove(sigint);
+        g_main_loop_unref(loop);
+
+        gbinder_servicename_unref(name);
+        gbinder_servicemanager_unref(svcmgr);
+        gbinder_local_object_drop(obj);
+        return RET_OK;
     } else {
-	g_main_loop_quit(user_data);
+        /* libgbinder prints the error in this case */
+        return RET_ERR;
     }
 }
 
-int main(int argc, char **argv) {
-    GMainLoop *loop;
-    GBinderServiceManager *svcmgr;
-    GBinderLocalObject *obj;
+int main(int argc, char* argv[])
+{
+    int ret = RET_CMDLINE;
+    char* dev = NULL;
+    GError* error = NULL;
+    GOptionContext* options = g_option_context_new(NULL);
+    GOptionEntry entries[] = {
+        { "verbose", 'v', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK,
+           netd_opt_verbose, "Enable debug output", NULL },
+        { "device", 'd', 0, G_OPTION_ARG_STRING, &dev,
+          "Binder device [" BINDER_DEVICE "]", "DEVICE" },
+        { NULL }
+    };
 
-    loop = g_main_loop_new(NULL, TRUE);
+    gutil_log_default.name = "dummy_netd";
+    gutil_log_timestamp = FALSE;
+    g_option_context_add_main_entries(options, entries, NULL);
+    if (g_option_context_parse(options, &argc, &argv, &error)) {
+        if (argc > 1) {
+            char* help = g_option_context_get_help(options, TRUE, NULL);
 
-    svcmgr = gbinder_servicemanager_new(BINDER_DEVICE);
-
-    obj = gbinder_servicemanager_new_local_object(svcmgr, NETD_IFACE, netd_reply, loop);
-    gbinder_servicemanager_add_service(svcmgr, NETD_SLOT, obj, add_service_done, loop);
-
-    g_main_loop_run(loop);
-
-    gbinder_local_object_unref(obj);
-    gbinder_servicemanager_unref(svcmgr);
-
-    g_main_loop_unref(loop);
-
-    return 0;
+            fprintf(stderr, "%s", help);
+            g_free(help);
+        } else {
+            ret = netd_run((dev && dev[0]) ? dev : BINDER_DEVICE);
+        }
+    } else {
+        GERR("%s", error->message);
+        g_error_free(error);
+    }
+    g_option_context_free(options);
+    g_free(dev);
+    return ret;
 }
-

--- a/rpm/dummy_netd.spec
+++ b/rpm/dummy_netd.spec
@@ -6,9 +6,14 @@ License:        BSD
 URL:            https://github.com/mer-hybris/dummy_netd
 Source:         %{name}-%{version}.tar.bz2
 
-BuildRequires:  libgbinder-devel >= 1.0.7
+%define libgbinder_version 1.0.26
+
+BuildRequires:  pkgconfig(libgbinder) >= %{libgbinder_version}
+BuildRequires:  pkgconfig(libglibutil)
 BuildRequires:  pkgconfig(libsystemd)
 BuildRequires:  pkgconfig(glib-2.0)
+
+Requires:       libgbinder >= %{libgbinder_version}
 
 %description
 dummy_netd provides the android.system.net.netd@1.1 service for devices which cannot work without it.


### PR DESCRIPTION
1. Use GBinderServiceName API to make sure that service gets registered even if servicemanager startup is delayed
2. Exit cleanly on SIGTERM
3. Made device name configurable from the command line
4. Added command line option for verbose logging. Disable all output by default.
5. Start or restart the service after installation
6. Require minimal version of libgbinder